### PR TITLE
Change Halo75 product name from 'Halo75' to 'NuPhy Halo75'

### DIFF
--- a/lib/nuphy.cpp
+++ b/lib/nuphy.cpp
@@ -141,7 +141,7 @@ static std::shared_ptr< NuPhy > createKeyboard(
     if (name == "Air75") {
         return std::make_shared< Air75 >(dataPath, requestPath, firmware);
     }
-    if (name == "Halo75") {
+    if (name == "NuPhy Halo75") {
         return std::make_shared< Halo75 >(dataPath, requestPath, firmware);
     }
     return nullptr;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nudelta",
     "author": "Mohamed Gaber <me@donn.website>",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "license": "GPL-3.0-or-later",
     "homepage": "https://github.com/donn/nudelta#readme",
     "description": "An open-source alternative to the NuPhy Console",


### PR DESCRIPTION
Resolves this: ![image](https://user-images.githubusercontent.com/12652988/210152558-9b99328f-8560-4718-b043-b63fb3acebe5.png)

Because screw consistency I guess.

(Screenshot courtesy of @nocturne1)